### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Donate](https://img.shields.io/badge/-%E2%99%A5%20Donate-%23ff69b4)](https://hmlendea.go.ro/fund.html) [![Latest GitHub release](https://img.shields.io/github/v/release/hmlendea/stellaris-ui-name-lists)](https://github.com/hmlendea/stellaris-ui-name-lists/releases/latest)
+
 # About
 
 Mod that added dozens of new and detailed name lists to Stellaris.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# stellaris-ui-name-lists
+# About
+
+Mod that added dozens of new and detailed name lists to Stellaris.
+
+The highlight is the "Human - Extended" list that contains thousands upon thousands of names from various languages, both from history and from fiction (especially space operas).
+There are also individual name lists for each of the used human language, or groups.
+
+Other name lists include ones taken from species from other games or movies such as `Galactic Civilizations`, `StarCraft`, `No Man's Sky`, `The Elder Scrolls`, `Star Wars`, and others

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 Mod that added dozens of new and detailed name lists to Stellaris.
 
+# Installation
+
+[![Get it from the Workshop](https://raw.githubusercontent.com/hmlendea/readme-assets/master/badges/stores/steam-workshop.png)](https://steamcommunity.com/sharedfiles/filedetails/?id=1912242707) [![Get it from the Nexus](https://raw.githubusercontent.com/hmlendea/readme-assets/master/badges/stores/nexus.png)](https://www.nexusmods.com/stellaris/mods/73)
+
+## Manual installation
+
+ - Download the [latest release](https://github.com/hmlendea/more-cultural-names/releases)
+ - Extract the contents into your game's mod directory
+
+# Features
+
 The highlight is the "Human - Extended" list that contains thousands upon thousands of names from various languages, both from history and from fiction (especially space operas).
 There are also individual name lists for each of the used human language, or groups.
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ OUTPUT_MOD_DIRECTORY_PATH="${OUTPUT_DIRECTORY_PATH}/${MOD_ID}"
 OUTPUT_NAMELISTS_DIRECTORY_PATH="${OUTPUT_MOD_DIRECTORY_PATH}/common/name_lists"
 OUTPUT_LOCALISATION_DIRECTORY_PATH="${OUTPUT_MOD_DIRECTORY_PATH}/localisation/english"
 OUTPUT_LOCALISATION_FILE_PATH="${OUTPUT_LOCALISATION_DIRECTORY_PATH}/ui_names_l_english.yml"
-GENERATOR_EXECUTABLE="dotnet /home/horatiu/Downloads/stellaris-name-list-generator/bin/Debug/netcoreapp3.1/StellarisNameListGenerator.dll"
+GENERATOR_EXECUTABLE="dotnet ../stellaris-name-list-generator/bin/Debug/net5.0/StellarisNameListGenerator.dll"
 
 MOD_THUMBNAIL_FILE_PATH="${OUTPUT_MOD_DIRECTORY_PATH}/thumbnail.png"
 MOD_DESCRIPTOR_PRIMARY_FILE_PATH="${OUTPUT_DIRECTORY_PATH}/${MOD_ID}.mod"

--- a/name-lists/human/common_hellenic.xml
+++ b/name-lists/human/common_hellenic.xml
@@ -454,6 +454,7 @@
             <string>Koursor</string>
             <string>Latinikon</string>
             <string>Myrmidon</string>
+            <string>Optimatoi</string>
             <string>Phalanx</string>
             <string>Stratioti</string>
             <string>Varangian</string>

--- a/name-lists/human/french.xml
+++ b/name-lists/human/french.xml
@@ -258,6 +258,7 @@
           <Values>
             <string>Arbalester</string>
             <string>Arquebusier</string>
+            <string>Coutilier</string>
             <string>Cuirassier</string>
             <string>Gendarme</string>
             <string>Musketeer</string>

--- a/name-lists/human/russian.xml
+++ b/name-lists/human/russian.xml
@@ -329,6 +329,7 @@
           <NameGroup>
             <Name>Guns</Name>
             <Values>
+              <string>Dushka</string>
               <string>Kalashnikov</string>
               <string>Papasha</string>
             </Values>


### PR DESCRIPTION
 - Fixed Undead Army names not being assigned _(**1**)_
 - Fixed the default sequencial names for the Industrial and Post-Atomic armies

_(**1**)_: The bug resulted in the whole application crashing